### PR TITLE
note on sdn-node; minion->node

### DIFF
--- a/beta-1-setup.md
+++ b/beta-1-setup.md
@@ -195,7 +195,7 @@ Then, edit the `/etc/sysconfig/openshift-sdn-node` file:
 
     MASTER_URL="http://fqdn.of.master:4001"
     
-    MINION_IP="ip.address.of.public.interface"
+    MINION_IP="ip.address.of.node.interface"
     
     OPTIONS="-v=4"
 
@@ -478,7 +478,7 @@ Edit the `/etc/sysconfig/openshift-sdn-node` file:
 
     MASTER_URL="http://fqdn.of.master:4001"
     
-    MINION_IP="ip.address.of.public.interface"
+    MINION_IP="ip.address.of.node.interface"
     
     OPTIONS="-v=4"
 
@@ -490,13 +490,15 @@ And start the SDN node:
 
 You may also want to enable the service.
 
+Note: If you check status on openshift-sdn-node, you will see that the service blocks with an error (and does not start openshift-node) until the node has been defined at the master in the next section.
+
 ### Adding the Node Via OpenShift's API
 The following JSON describes a node:
 
     cat node.json
     {
       "id": "ose3-node1.example.com",
-      "kind": "Minion",
+      "kind": "Node",
       "apiVersion": "v1beta1",
     }
 
@@ -512,7 +514,7 @@ again:
 You should now have two running nodes in addition to your original "master"
 node (it may take a minute for all to reach "Ready" status):
 
-    osc get minions
+    osc get nodes
     NAME                      LABELS              STATUS
     ose3-master.example.com   <none>              Ready
     ose3-node1.example.com    <none>              Ready

--- a/node.json
+++ b/node.json
@@ -1,5 +1,5 @@
 {
   "id": "ose3-node1.example.com",
-  "kind": "Minion",
+  "kind": "Node",
   "apiVersion": "v1beta1",
 }


### PR DESCRIPTION
After starting openshift-sdn-node I checked status and saw errors, and saw that openshift-node wasn't started. This was alarming. I expect users to do the same, so reassure them that this is normal.

Also, "Minion" has been deprecated in favor of "Node".
And I thought "public" is a confusing word for a NIC IP in the context of EC2/OpenStack.
