### PR TITLE
Update expected haproxy routes.json

### DIFF
--- a/beta-1-setup.md
+++ b/beta-1-setup.md
@@ -745,9 +745,13 @@ If you see some content that looks like:
 
     "hello-openshift-service": {
       "Name": "hello-openshift-service",
-      "HostAliases": [
-        "hello-openshift.cloudapps.example.com"
-      ],
+      ...
+      "ServiceAliasConfigs": {
+        "hello-openshift.cloudapps.example.com-": {
+          "Host": "hello-openshift.cloudapps.example.com",
+          ...
+         }
+      }
 
 You know that "it" worked -- the router watcher detected the creation of the
 route in OpenShift and added the corresponding configuration to HAProxy.


### PR DESCRIPTION
I think the format has changed since this was written. Check for yourself... this is what mine looks like:

```
  "hello-openshift-service": {
    "Name": "hello-openshift-service",
    "EndpointTable": {
      "10.1.0.19:8080": {
        "ID": "10.1.0.19:8080",
        "IP": "10.1.0.19",
        "Port": "8080"
      }
    },
    "ServiceAliasConfigs": {
      "hello-openshift.cloudapps.example.com-": {
        "Host": "hello-openshift.cloudapps.example.com",
        "Path": "",
        "TLSTermination": "",
        "Certificates": null
      }
    }
  },
```
