### PR TITLE
Updating image name to new ruby-20-centos7

### DIFF
--- a/beta-2-setup.md
+++ b/beta-2-setup.md
@@ -129,7 +129,7 @@ On all of your systems, grab the following docker images:
 It may be advisable to pull the following Docker images as well, since they are
 used during the various labs:
 
-    docker pull openshift/ruby-20-centos
+    docker pull openshift/ruby-20-centos7
     docker pull mysql
     docker pull openshift/hello-openshift
 
@@ -1396,7 +1396,7 @@ following on your connected machine:
     docker pull registry.access.redhat.com/openshift3_beta/ose-docker-builder
     docker pull registry.access.redhat.com/openshift3_beta/ose-pod
     docker pull registry.access.redhat.com/openshift3_beta/ose-docker-registry
-    docker pull openshift/ruby-20-centos
+    docker pull openshift/ruby-20-centos7
     docker pull mysql
     docker pull openshift/hello-openshift
 
@@ -1409,7 +1409,7 @@ This will fetch all of the images. You can then save them to a tarball:
     registry.access.redhat.com/openshift3_beta/ose-docker-builder \
     registry.access.redhat.com/openshift3_beta/ose-pod \
     registry.access.redhat.com/openshift3_beta/ose-docker-registry \
-    openshift/ruby-20-centos \
+    openshift/ruby-20-centos7 \
     mysql \
     openshift/hello-openshift
 

--- a/beta2/integrated-build.json
+++ b/beta2/integrated-build.json
@@ -50,7 +50,7 @@
     },
     {
       "metadata":{
-        "name": "ruby-20-centos",
+        "name": "ruby-20-centos7",
       },
       "kind": "ImageRepository",
       "apiVersion": "v1beta1",
@@ -77,8 +77,8 @@
         {
           "type": "imageChange",
           "imageChange": {
-            "image": "openshift/ruby-20-centos",
-            "from": { "name": "ruby-20-centos"},
+            "image": "openshift/ruby-20-centos7",
+            "from": { "name": "ruby-20-centos7"},
             "tag":"latest"
           }
         }
@@ -93,8 +93,8 @@
         "strategy": {
           "type": "STI",
           "stiStrategy": {
-            "image": "openshift/ruby-20-centos",
-            "scripts": "https://raw.githubusercontent.com/openshift/ruby-20-centos/master/.sti/bin"
+            "image": "openshift/ruby-20-centos7",
+            "scripts": "https://raw.githubusercontent.com/openshift/sti-ruby/master/2.0/.sti/bin"
           }
         },
         "output": {


### PR DESCRIPTION
There is a new ruby-20 image(ruby-20-centos7) and we are going to get rid of the old one(ruby-20-centos)
