### PR TITLE
Update the branch used for the ansible checkout

### DIFF
--- a/beta-2-setup.md
+++ b/beta-2-setup.md
@@ -184,7 +184,7 @@ Github. Clone the repository:
     cd
     git clone https://github.com/detiber/openshift-ansible.git
     cd ~/openshift-ansible
-    git checkout enterprise2
+    git checkout v3-beta2
 
 ### Configure Ansible
 Move the staged Ansible configuration files to `/etc/ansible`:


### PR DESCRIPTION
Since enterprise2 is a bit confusing and I don't want to keep iterating on changes while the training is ongoing. The v3-beta2 will only get refreshed as requested.
