### PR TITLE
promote openshift ex router|registry|new-project|config to non-ex locations

### DIFF
--- a/beta-3-setup.md
+++ b/beta-3-setup.md
@@ -313,17 +313,17 @@ extra. This extra thing is the routing layer. The router is the ingress point
 for all traffic destined for OpenShift v3 services. It currently supports only
 HTTP(S) traffic (and "any" TLS-enabled traffic via SNI).
 
-OpenShift's "experimental" command set enables you to install the router
+OpenShift's admin command set enables you to install the router
 automatically. Try running it with no options and you should see the note that a
 router is needed:
 
-    openshift ex router
+    osadm router
     F0223 11:50:57.985423    2610 router.go:143] Router "router" does not exist
     (no service). Pass --create to install.
 
 So, go ahead and do what it says:
 
-    openshift ex router --create
+    osadm router --create
     F0223 11:51:19.350154    2617 router.go:148] You must specify a .kubeconfig
     file path containing credentials for connecting the router to the master
     with --credentials
@@ -335,7 +335,7 @@ credentials the *router* should use to communicate. We also need to specify the
 router image, since currently the experimental tooling points to
 upstream/origin:
 
-    openshift ex router --create \
+    osadm router --create \
     --credentials=/var/lib/openshift/openshift.local.certificates/openshift-router/.kubeconfig \
     --images='registry.access.redhat.com/openshift3_beta/ose-${component}:${version}'
 
@@ -364,10 +364,10 @@ Docker images from your source code and deploy and manage their lifecycle. In
 order to do this, OpenShift can host its own Docker registry in
 order to pull images "locally". Let's take a moment to set that up.
 
-`openshift ex` again comes to our rescue with a handy installer for the
+`osadm` again comes to our rescue with a handy installer for the
 registry:
 
-    openshift ex registry --create \
+    osadm registry --create \
     --credentials=/var/lib/openshift/openshift.local.certificates/openshift-registry/.kubeconfig \
     --images='registry.access.redhat.com/openshift3_beta/ose-${component}:${version}'
 
@@ -2020,16 +2020,16 @@ This all looks good for now.
 ### That Project Thing
 As `root`, create a new project for Wordpress for `alice`:
 
-    openshift ex new-project wordpress --display-name="Wordpress" \
+    osadm new-project wordpress --display-name="Wordpress" \
     --description='Building an arbitrary Wordpress Docker image' \
     --admin=htpasswd:alice
 
 As `alice`:
 
     cd ~/.kube
-    openshift ex config set-context wordpress --cluster=ose3-master.example.com:8443 \
+    osc config set-context wordpress --cluster=ose3-master.example.com:8443 \
     --namespace=wordpress --user=alice
-    openshift ex config use-context wordpress
+    osc config use-context wordpress
 
 ### Build Wordpress
 Let's choose the Wordpress example:
@@ -2323,7 +2323,7 @@ to limit some of what it returns:
         # If a stale token exists it will prevent the beta2 login command from working
         rm .kubeconfig
 
-        openshift ex login \
+        osc login \
         --certificate-authority=/var/lib/openshift/openshift.local.certificates/ca/root.crt \
         --cluster=master --server=https://ose3-master.example.com:8443 \
         --namespace=[INSERT NAMESPACE HERE]


### PR DESCRIPTION
Start directing folks to `osadm` where admin things live now (alias for `openshift admin`).
`config` has gone to `osc config`.
