### PR TITLE
Rewrite hooks section to be included in wiring example

### DIFF
--- a/beta-3-setup.md
+++ b/beta-3-setup.md
@@ -2540,9 +2540,10 @@ too.
 Since we already have our `wiring` app pointing at our forked code repository,
 let's go ahead and add a database migration file. In the `beta3` folder you will
 find a file called `1_sample_table.rb`. Add this file to the `db/migrate` folder
-of the `ruby-hello-world` repository that you forked.
+of the `ruby-hello-world` repository that you forked. If you don't add this file
+to the right folder, the rest of the steps will fail.
 
-### Examining the Configuration
+### Examining the Deployment Configuration
 Since we are talking about **deployments**, let's look at our
 `DeploymentConfig`s. As the `alice` user in the `wiring` project:
 
@@ -2729,6 +2730,103 @@ different passwords for you. Remember, indentation isn't critical in JSON, but
 closing brackets and braces are.
 
 When you are done editing the deployment config, save and quit your editor.
+
+### Quickly Clean Up
+When we did our previous builds and rollbacks and etc, we ended up with a lot of
+stale pods that are not running (`Succeeded`). Currently we do not auto-delete
+these pods because we have no log store -- once they are deleted, you can't view
+their logs any longer.
+
+For now, we can clean up by doing the following as `alice`:
+
+    osc get pod |\
+    grep -E "lifecycle|sti-build" |\
+    awk {'print $1'} |\
+    xargs -r osc delete pod
+
+This will get rid of all of our old build and lifecycle pods. The lifecycle pods
+are the pre- and post-deployment hook pods, and the sti-build pods are the pods
+in which our previous builds occurred.
+
+### Build Again
+Now that we have modified the deployment configuration and cleaned up a bit, we
+need to trigger another deployment. While killing the frontend pod would trigger
+another deployment, our current Docker image doesn't have the database migration
+file in it. Nothing really useful would happen.
+
+In order to get the database migration file into the Docker image, we actually
+need to do another build. Remember, the STI process starts with the builder
+image, fetches the source code, executes the (customized) assemble script, and
+then pushes the resulting Docker image into the registry. **Then** the
+deployment happens.
+
+As `alice`:
+
+    osc start-build ruby-sample-build
+
+### Verify the Migration
+Once the build is complete, you should see something like the following output
+of `osc get pod` as `alice`:
+
+    POD                                IP          CONTAINER(S)               IMAGE(S)                                                                                                       HOST                                    LABELS                                                                                                                  STATUS      CREATED
+    database-1-6lvao                   10.1.0.13   ruby-helloworld-database   registry.access.redhat.com/openshift3_beta/mysql-55-rhel7                                                      ose3-master.example.com/192.168.133.2   deployment=database-1,deploymentconfig=database,name=database,template=application-template-stibuild                    Running     2 hours
+    deployment-frontend-9-hook-wlqqx               lifecycle                  172.30.17.24:5000/wiring/origin-ruby-sample:85e3393a2827ae4ce42ea6abf45a08e42d7c0d5f527f6415d35a4d4847392ed1   ose3-master.example.com/192.168.133.2   <none>                                                                                                                  Succeeded   4 minutes
+    frontend-9-cb4u9                   10.1.0.56   ruby-helloworld            172.30.17.24:5000/wiring/origin-ruby-sample:85e3393a2827ae4ce42ea6abf45a08e42d7c0d5f527f6415d35a4d4847392ed1   ose3-master.example.com/192.168.133.2   deployment=frontend-9,deploymentconfig=frontend,name=frontend,template=application-template-stibuild                    Running     3 minutes
+    ruby-sample-build-6                            sti-build                  openshift3_beta/ose-sti-builder:v0.4.3.2                                                                       ose3-master.example.com/192.168.133.2   build=ruby-sample-build-6,buildconfig=ruby-sample-build,name=ruby-sample-build,template=application-template-stibuild   Succeeded   5 minutes
+
+You'll see that there is a single `hook`/`lifecycle` pod -- this corresponds
+with the pod that ran our pre-deployment hook.
+
+Inspect this pod's logs:
+
+    osc log deployment-frontend-9-hook-wlqqx -n wiring
+
+**Note:** You'll have to perform this as `root`.
+
+The output likely shows:
+
+    2015-04-29T22:17:30.928941999Z == 1 SampleTable: migrating
+    ===================================================
+    2015-04-29T22:17:30.929014043Z -- create_table(:sample_table)
+    2015-04-29T22:17:30.929021057Z    -> 0.0995s
+    2015-04-29T22:17:30.929024656Z == 1 SampleTable: migrated (0.0999s)
+    ==========================================
+    2015-04-29T22:17:30.929027404Z
+
+If you have no output, you may have forgotten to actually put the migration file
+in your repo. Without that file, the migration does nothing, which produces no
+output.
+
+For giggles, you can even talk directly to the database on its service IP/port
+using the `mysql` client and the environment variables.
+
+As `alice`, find your database:
+
+    NAME       LABELS                                   SELECTOR        IP            PORT(S)
+    database   template=application-template-stibuild   name=database   172.30.17.5   5434/TCP
+
+Then, somewhere inside your OpenShift environment, use the `mysql` client to
+connect to this service and dump the table that we created:
+
+    mysql -u userJKL \
+      -p 5678efgh \
+      -h 172.30.17.208 \
+      -P 5434 \
+      -e 'show tables; describe sample_table;' \
+      root
+    +-------------------+
+    | Tables_in_root    |
+    +-------------------+
+    | sample_table      |
+    | key_pairs         |
+    | schema_migrations |
+    +-------------------+
+    +-------+--------------+------+-----+---------+----------------+
+    | Field | Type         | Null | Key | Default | Extra          |
+    +-------+--------------+------+-----+---------+----------------+
+    | id    | int(11)      | NO   | PRI | NULL    | auto_increment |
+    | name  | varchar(255) | NO   |     | NULL    |                |
+    +-------+--------------+------+-----+---------+----------------+
 
 ## Arbitrary Docker Image (Builder)
 One of the first things we did with OpenShift was launch an "arbitrary" Docker
@@ -3299,272 +3397,3 @@ HTTPS_PROXY=https://USER:PASSWORD@IPADDR:PORT
 
 We're working to have a single place that administrators can set proxies for
 all network traffic.
-
-# APPENDIX - Lifecycle Pre and Post Deployment Hooks
-
-## Set up app template
-
-For this, `training/beta3/integrated-template.json` works fine
-
-    cd
-    cp training/beta3/integrated-template.json ./my-template.json
-
-### Modify the BuildConfig source to point to your fork
-
-It should end up looking something like this:
-
-    {
-      "kind": "BuildConfig",
-      "apiVersion": "v1beta1",
-    ...
-          "parameters": {
-            "source": {
-              "type": "Git"
-              "git": {
-                "uri": "git://github.com/YOUR_GITHUB_USER/ruby-hello-world.git",
-                "ref": "beta3"
-              },
-            },
-            "strategy": {
-              "type": "STI",
-              "stiStrategy": {
-                "builderImage": "openshift/ruby-20-centos7",
-                "image": "openshift/ruby-20-centos7"
-              }
-            },
-            "output": {
-              "to": {
-                "kind": "ImageStream",
-                "name": "origin-ruby-sample"
-              }
-            }
-          }
-    ...
-    }
-
-## Create a new project for your app
-
-Modify `--admin=` to reference the user you want to own the project.
-
-    osadm new-project myapp \
-      --display-name="My App" \
-      --description="My test app template" \
-      --admin=admin
-
-## As the project owner, switch to the new project
-
-    osc project myapp
-
-## Create the template
-
-    osc create -f ./my-template.json
-
-## Create an app from the template
-
-In the web console, as the project owner user:
--   click "+Create"
--   select `quickstart-keyvalue-application` or whatever
--   click "Select template..."
--   click "Create"
--   watch the tiny computer men build an application!
-
-## Verify the app is up and running
-
-## Create a branch in your fork of the `ruby-hello-world` app
-
-    cd /path/to/ruby-hello-world
-    git checkout -b newtable my_remote/beta3
-
-## Add a new table by creating a new migration in `db/migrate`
-
-    cat <<EOF > db/migrate/1_sample_table.rb
-
-    class SampleTable < ActiveRecord::Migration
-      def up
-        create_table :sample_table do |t|
-          t.column :name, :string, :null => false
-        end
-      end
-      def down
-        drop_table :sample_table
-      end
-    end
-
-    EOF
-
-## Push the changes to your github account
-
-    git add db/migrate/1_sample_table.rb
-    git commit -m 'Add a new db migration'
-    git push my_remote newtable:newtable
-
-## Modify the buildConfig to reference the new branch
-
-    osc edit -ojson bc/ruby-sample-build
-
-### update the `git` `ref` parameter
-
-You should wind up with a section that looks like:
-
-    ...
-            "source": {
-              "git": {
-                "uri": "git://github.com/YOUR_GITHUB_USER/ruby-hello-world.git",
-                "ref": "newtable"
-              },
-              "type": "Git"
-            },
-    ...
-
-## Get the MySQL/MariaDB parameters from the `database` `deploymentConfig`
-
-The `database` deployment configuration will contain the correct
-MariaDB parameters and credentials. Copy these out for use in the
-lifecycle hook definition later:
-
-    # osc get dc database -ojson | grep -C2 '"key": "MYSQL' | grep -v '"key":' > env.json
-
-## Modify the deploymentConfig to run the database migration as a post-deployment lifecycle hook
-
-    osc edit -ojson dc/frontend
-
-### Add the desired lifecycle hook
-
-The hook should run the command with the appropriate environment in
-the correct directory, like:
-
-    /usr/bin/scl enable ruby200 ror40 'cd /opt/openshift/src ; bundle exec rake db:migrate'
-
-...but expressed as a string array in `json`:
-
-    "command": [
-        "/usr/bin/scl",
-        "enable",
-        "ruby200",
-        "ror40",
-        "cd /opt/openshift/src ; bundle exec rake db:migrate"
-    ]
-
-#### create/modify the `recreateParams` `post` hook definition for the template strategy
-
-Don't forget to copy & paste the `env` variable definitions from
-the `env.json` file you created earlier. You should end up with a
-section that looks like:
-
-    ...
-        "template": {
-            "strategy": {
-                "type": "Recreate",
-                "recreateParams": {
-    
-    ...
-                    "post": {
-                        "failurePolicy": "Ignore",
-                        "execNewPod": {
-                            "command": [
-                                "/usr/bin/scl",
-                                "enable",
-                                "ruby200",
-                                "ror40",
-                                "cd /opt/openshift/src ; bundle exec rake db:migrate"
-                            ],
-                            "env": [
-                                {
-                                    "name": "MYSQL_USER",
-                                    "value": "userJKL"
-                                },
-                                {
-                                    "name": "MYSQL_PASSWORD",
-                                    "value": "5678efgh"
-                                },
-                                {
-                                    "name": "MYSQL_DATABASE",
-                                    "value": "root"
-                                }
-                            ],
-                            "containerName": "ruby-helloworld"
-                        }
-                    }
-    ...
-
-## Kick off the new build:
-
-    osc start-build ruby-sample-build
-
-Monitor the build logs, and note the docker image tag, which should
-be output towards the end of the build on a line similar to this:
-
-    2015-04-23T19:59:34.304730547Z I0423 15:59:34.303984       1 sti.go:236] Tagged e696bbc88d892473a593b4e074483888e696bbc88d892473a593b4e074483888 as 172.30.17.99:5000/myapp2/origin-ruby-sample
-
-At this point the deployment should run, including your revised
-post-deploy lifecycle hook. You can verify this by looking for the
-deployment hook pods in the `osc get pods` output:
-
-    # osc get pods | grep 'POD\|lifecycle'
-    POD                                IP CONTAINER(S) IMAGE(S)                                                                                                    HOST                                  LABELS STATUS    CREATED
-    deployment-frontend-1-hook-hgr3a      lifecycle    172.30.17.43:5000/myapp/origin-ruby-sample:2003ffa35bf573181d6be7eba720d05c2003ffa35bf573181d6be7eba720d05c ose3-master.example.com/192.168.133.2 <none> Succeeded About an hour
-    deployment-frontend-1-hook-owy4k      lifecycle    172.30.17.43:5000/myapp/origin-ruby-sample:2003ffa35bf573181d6be7eba720d05c2003ffa35bf573181d6be7eba720d05c ose3-master.example.com/192.168.133.2 <none> Succeeded About an hour
-    deployment-frontend-2-hook-im42n      lifecycle    172.30.17.43:5000/myapp/origin-ruby-sample:e696bbc88d892473a593b4e074483888e696bbc88d892473a593b4e074483888 ose3-master.example.com/192.168.133.2 <none> Pending   8 seconds
-    deployment-frontend-2-hook-hejef      lifecycle    172.30.17.43:5000/myapp/origin-ruby-sample:e696bbc88d892473a593b4e074483888e696bbc88d892473a593b4e074483888 ose3-master.example.com/192.168.133.2 <none> Pending   9 seconds
-
-The pods with the most recent `CREATED` time will be the lifecycle
-hook pods triggered by your build. It may take a few moments after the
-build completes for the pods to show up, so you will want to keep
-monitoring this command until the pods appear. You'll notice that the
-docker image tag from your build logs will appear in the `IMAGE(S)`
-field for your hook pods.
-
-Once the pods' `STATUS` move from `Pending` to `Succeeded`, you can
-inspect them to see the result.
-
-## Verify that the database migration happened
-
-Find the deployment hooks in the output from `osc get pods` and
-inspect them with `osc log`:
-
-    # osc get pods | grep 'deployment-frontend-2'
-    deployment-frontend-2-hook-im42n lifecycle 172.30.17.43:5000/myapp/origin-ruby-sample:e696bbc88d892473a593b4e074483888e696bbc88d892473a593b4e074483888 ose3-master.example.com/192.168.133.2 <none> Pending   8 seconds
-    deployment-frontend-2-hook-hejef lifecycle 172.30.17.43:5000/myapp/origin-ruby-sample:e696bbc88d892473a593b4e074483888e696bbc88d892473a593b4e074483888 ose3-master.example.com/192.168.133.2 <none> Succeeded 17 seconds
-
-    # osc log deployment-frontend-2-hook-im42n
-
-Theres no output from this command; this probably means that this pod
-had run the pre-deployment lifecycle hook which (at the time of this
-writing) runs `/bin/true`. Let's check the next pod's logs:
-
-    # osc log deployment-frontend-2-hook-hejef
-    2015-04-23T17:48:41.588240012Z == 1 SampleTable: migrating ======================================================
-    2015-04-23T17:48:41.588312703Z -- create_table(:sample_table)
-    2015-04-23T17:48:41.588318626Z    -> 0.2923s
-    2015-04-23T17:48:41.588322977Z == 1 SampleTable: migrated (0.3026s) =============================================
-    2015-04-23T17:48:41.588326799Z
-
-Pay dirt! Here we can see the output we'd expect from a successful
-Rails database migration.
-
-Now use the MySQL credentials from `env.json` and the host IP/port
-for the database service to inspect the database (you may need to
-install the `mysql` client):
-
-    # osc get svc database
-    NAME       LABELS                                   SELECTOR        IP              PORT(S)
-    database   template=application-template-stibuild   name=database   172.30.17.208   5434/TCP
-    # mysql -u userJKL \
-      -p 5678efgh \
-      -h 172.30.17.208 \
-      -P 5434 \
-      -e 'show tables; describe sample_table;' \
-      root
-    +-------------------+
-    | Tables_in_root    |
-    +-------------------+
-    | sample_table      |
-    | key_pairs         |
-    | schema_migrations |
-    +-------------------+
-    +-------+--------------+------+-----+---------+----------------+
-    | Field | Type         | Null | Key | Default | Extra          |
-    +-------+--------------+------+-----+---------+----------------+
-    | id    | int(11)      | NO   | PRI | NULL    | auto_increment |
-    | name  | varchar(255) | NO   |     | NULL    |                |
-    +-------+--------------+------+-----+---------+----------------+

--- a/beta3/1_sample_table.rb
+++ b/beta3/1_sample_table.rb
@@ -1,0 +1,10 @@
+class SampleTable < ActiveRecord::Migration
+  def up
+    create_table :sample_table do |t|
+      t.column :name, :string, :null => false
+    end
+  end
+  def down
+    drop_table :sample_table
+  end
+end


### PR DESCRIPTION
The wiring example already laid the groundwork for an easy place to continue with deployment hooks. I just moved the appendix into a new section just after the activate/rollback section using the information that was already there. I cleaned it up a little bit after that.
