### PR TITLE
Fix security group configuration

### DIFF
--- a/beta3/ansible-aws/util_playbooks/create_security_groups.yml
+++ b/beta3/ansible-aws/util_playbooks/create_security_groups.yml
@@ -20,18 +20,22 @@
         to_port: 22
         cidr_ip: 0.0.0.0/0
       - proto: tcp
+        from_port: 80
+        to_port: 80
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        from_port: 443
+        to_port: 443
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
         from_port: 10250
         to_port: 10250
         group_name: openshift-v3-training-master
         group_desc: OpenShift v3 Training Master Security Group
-      - proto: tcp
-        from_port: 53
-        to_port: 53
-        group_name: openshift-v3-training-master
       - proto: udp
-        from_port: 53
-        to_port: 53
-        group_name: openshift-v3-training-master
+        from_port: 4789
+        to_port: 4789
+        group_name: openshift-v3-training-node
       rules_egress:
       - proto: all
         cidr_ip: 0.0.0.0/0
@@ -45,6 +49,14 @@
         from_port: 22
         to_port: 22
         cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        from_port: 53
+        to_port: 53
+        group_name: openshift-v3-training-node
+      - proto: udp
+        from_port: 53
+        to_port: 53
+        group_name: openshift-v3-training-node
       - proto: tcp
         from_port: 8443
         to_port: 8443


### PR DESCRIPTION
Allow sdn traffic between nodes, allow http/https ports to nodes, and move dns ports to master security group.
