### PR TITLE
Update beta-3-setup.md

### DIFF
--- a/beta-3-setup.md
+++ b/beta-3-setup.md
@@ -3544,7 +3544,7 @@ If you had previously imported ImageStreams without the proxy configuration to c
 
 ~~~
 osc delete imagestreams -n openshift --all
-osc create -f image-streams.json
+osc create -f image-streams.json -n openshift
 ~~~
 
 ## STI Builds


### PR DESCRIPTION
The imagestreams should be imported to the openshift namespace, otherwise they won't be available for all users.
