### PR TITLE
Update service json to match routing example

### DIFF
--- a/beta-3-setup.md
+++ b/beta-3-setup.md
@@ -1065,7 +1065,7 @@ If you think back to the simple pod we created earlier, there was a "label":
 Now, let's look at a *service* definition:
 
     {
-      "id": "hello-openshift",
+      "id": "hello-openshift-service",
       "kind": "Service",
       "apiVersion": "v1beta1",
       "port": 27017,


### PR DESCRIPTION
The Routing and complete Pod-Service-Route json examples refer to
the service as 'hello-openshift-service' while the service example it self
define the service with id 'hello-openshift'.
