### PR TITLE
Fixed command listing sinatra app

### DIFF
--- a/08-S2I-Introduction.md
+++ b/08-S2I-Introduction.md
@@ -60,7 +60,7 @@ For this example, we will be using the following application's source code:
 
 Let's see some JSON:
 
-    oc new-app -o json https://github.com/openshift/simple-openshift-sinatra-sti.git
+    oc new-app -o json --strategy=source https://github.com/openshift/simple-openshift-sinatra-sti.git
 
 Take a look at the JSON that was generated. You will see some familiar items at
 this point, and some new ones, like `BuildConfig`, `ImageStream` and others.


### PR DESCRIPTION
Unless strategy is specified, `oc new-app` produces just:

```
error: none of the images that match "ruby" can build source code -
check whether this is the image you want to use, then use
--strategy=source to build using source or --strategy=docker to
treat this as a Docker base image and set up a layered Docker build
```

Signed-off-by: Michal Minar miminar@redhat.com
