### PR TITLE
[bugfix] Update atomic-openshift-installer command syntax

### DIFF
--- a/02-Installation-and-Scheduler.md
+++ b/02-Installation-and-Scheduler.md
@@ -52,7 +52,7 @@ accordingly.
 ## Run the Installer
 As `root` in `/root`, go ahead and run the installer:
 
-    atomic-openshift-installer -a openshift-ansible/
+    atomic-openshift-installer -a openshift-ansible/ install
 
 You will see:
 


### PR DESCRIPTION
If you run atomic-openshift-installer as documented, you will receive the following error:

```
Usage: atomic-openshift-installer [OPTIONS] COMMAND [ARGS]...

Error: Invalid value for "--ansible-playbook-directory" / "-a": Directory "openshift-ansible/" does not exist.
```

Patch updates to use proper command syntax of:
`atomic-openshift-installer -a openshift-ansible/ install`
