### PR TITLE
Change sourceStrategy for ruby-sample-build

### DIFF
--- a/content/quickstart-template.json
+++ b/content/quickstart-template.json
@@ -121,8 +121,7 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "ruby:latest",
-              "namespace": "openshift"
+              "name": "ruby-20-rhel7:latest"
             },
             "incremental": true
           }


### PR DESCRIPTION
It use by default the ruby IS in openshift namespace :

``` bash
 oc -n openshift describe is ruby
Name:                   ruby
Created:                7 hours ago
Labels:                 <none>
Annotations:            openshift.io/image.dockerRepositoryCheck=2016-01-21T08:53:53Z
Docker Pull Spec:       172.30.77.44:5000/openshift/ruby

Tag     Spec                                                            Created         PullSpec                                                        Image
2.0     registry.access.redhat.com/openshift3/ruby-20-rhel7:latest      7 hours ago     registry.access.redhat.com/openshift3/ruby-20-rhel7:latest      901b89353cfe7a1c6f6c31d57f89a989b08cf9fd384fcadec6f35a03c95f5ea4
2.2     registry.access.redhat.com/rhscl/ruby-22-rhel7:latest           7 hours ago     registry.access.redhat.com/rhscl/ruby-22-rhel7:latest           9416bc460d0c5f962db64dd43ae4a364ff480d883fb50cb0df1bc4808b377217
latest  2.2                                                             7 hours ago     registry.access.redhat.com/rhscl/ruby-22-rhel7:latest           9416bc460d0c5f962db64dd43ae4a364ff480d883fb50cb0df1bc4808b377217
```

In this case the latest is rhscl/ruby-22-rhel7 and this image is not compatible with the app.

I think we need to use the IS created in the template, not the openshift IS
