### PR TITLE
Add PROXY param into quickstart-template.json

### DIFF
--- a/content/quickstart-template.json
+++ b/content/quickstart-template.json
@@ -112,6 +112,8 @@
         "source": {
           "type": "Git",
           "git": {
+            "httpProxy": "${PROXY}",
+            "httpsProxy": "${PROXY}",
             "uri": "git://github.com/openshift/ruby-hello-world.git",
             "ref": "beta4"
           }
@@ -119,6 +121,16 @@
         "strategy": {
           "type": "Source",
           "sourceStrategy": {
+            "env": [
+              {
+                "name": "http_proxy",
+                "value": "${PROXY}"
+              },
+              {
+                "name": "https_proxy",
+                "value": "${PROXY}"
+              }
+            ],
             "from": {
               "kind": "ImageStreamTag",
               "name": "ruby:latest",
@@ -341,6 +353,10 @@
     }
   ],
   "parameters": [
+    { 
+      "name": "PROXY",
+      "description": "The proxy url used for github and system (e.g: http://10.205.0.4:8080 )"
+    },
     {
       "name": "MYSQL_USER",
       "description": "The username used to connect to the database",


### PR DESCRIPTION
Update content/quickstart-template.json with a PROXY param if you have to use a proxy for github and system.
