### PR TITLE
docs/05-cleanup: Talk about metadata.json

### DIFF
--- a/docs/05-cleanup.md
+++ b/docs/05-cleanup.md
@@ -1,7 +1,7 @@
 # Deleting the Cluster and Cleaning up
 Cleaning up your cluster is trivial. However, on the off chance that the
 cleanup fails, you will be left with AWS resources that are undeleted.
-Finding them can be tricky, but they all have a key:value tag of
+Finding them can be tricky, but they have a key:value tag of
 `openshiftClusterID:<cluster_uuid>` and then you can carefully delete them by
 hand.
 
@@ -11,11 +11,16 @@ Just in case, be sure to grab the UUID before destroying the cluster:
 
 If you are trying to destroy your cluster because of a failed installation,
 you may not be able to use `oc`. In that case, you can look for the UUID in
-one of the state files:
+the `metadata.json` asset:
 
-    grep '"clusterID"' .openshift_install_state.json
+    jq -r .clusterID metadata.json
 
-The following command will then remove the OpenShift 4 cluster and all the
-underlying AWS resources that were created by the installer:
+The following command will read `metadata.json` and remove the
+OpenShift 4 cluster and all underlying AWS resources that were created
+by the installer:
 
     ./openshift-install destroy cluster
+
+As for `create`, you can set `--dir` to use an asset directory other
+than your current working directory.  You should use the same asset
+directory for `destroy` that you used for `create`.


### PR DESCRIPTION
And use `jq` to extract the cluster ID from the metadata file, since that's where `openshift-install destroy cluster` gets the information.

Also, one small quibble is that most, not all, resources are tagged with `openshiftClusterID`.  Those resources are also tagged with `kubernetes.io/cluster/{clusterName}: owned`, and a few resources are *only* tagged with the `kubernetes.io` tag (because they are created by upstream Kubernetes tooling that does not provide knobs to add additional tags, or because an OpenShift operator doesn't yet use existing knobs).  And some resources aren't tagged at all, because AWS only supports tagging for some resource types.  Still, `openshiftClusterID` gets the general idea across, so I've just removed "all" and kept the weed-wading to this message ;).