### PR TITLE
nodes/02-redhat-coreos: Remove space before crictl

### DIFF
--- a/docs/nodes/02-redhat-coreos.md
+++ b/docs/nodes/02-redhat-coreos.md
@@ -86,7 +86,7 @@ Inspected and debugged via `crictl`
 To view running pods via `crictl`, execute the following:
 
 ```sh
- sudo crictl pods
+sudo crictl pods
 ```
 
 ## Podman


### PR DESCRIPTION
To match the other fenced shell sections in this file.