### PR TITLE
docs/01-prerequisites: No pre-formatting for "Configure everything ..."

### DIFF
--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -88,13 +88,17 @@ After installing the AWS CLI, it must be configured for the AWS account and
 IAM role. This assumes we are using the `openshift4-beta-admin` IAM user
 mentioned earlier:
 
-```
+```console
 $ aws configure --profile=openshift4-beta-admin
 AWS Access Key ID [None]: <for the AWS role openshift4-beta-admin >
 AWS Secret Access Key [None]: <for the AWS role openshift4-beta-admin>
 Default region name [None]: <the AWS region to deploy the beta environment>
 Default output format [None]: text
+```
+
 Configure everything to use this new profile
+
+```console
 $ export AWS_PROFILE=openshift4-beta-admin
 ```
 


### PR DESCRIPTION
We added this line for context, it's not part of the `aws configure ...` session.

Also use console syntax highlighting here.  GitHub [uses Linguist for syntax highlighting][1], and Linguist defines two related grammars:

* [Shell (alias `sh`)][2], which applies to POSIX and similar shell languages.

* [ShellSession (alias `console`)][3], which extends the Shell grammar with support for prompts and command output as you would usually see in an interactive shell session.

The `aws configure` invocation includes output, so it deserves `console` highlighting.  The `export` command could go either way, but it had a prompt before this commit, so I've gone with `console` highlighting there too (and it's nice to have a consistent approach).

[1]: https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
[2]: https://github.com/github/linguist/blob/v7.1.3/lib/linguist/languages.yml#L4465-L4526
[3]: https://github.com/github/linguist/blob/v7.1.3/lib/linguist/languages.yml#L4527-L4538