### PR TITLE
docs: Drop openshiftClusterID

### DIFF
--- a/docs/05-infrastructure-nodes.md
+++ b/docs/05-infrastructure-nodes.md
@@ -253,8 +253,6 @@ spec:
               values:
               - 190125-3-worker-us-west-1b
           tags:
-          - name: openshiftClusterID
-            value: 45d08e94-6bf6-4fd3-988f-54a616d04252
           - name: kubernetes.io/cluster/190125-3
             value: owned
           userDataSecret:

--- a/docs/06-cleanup.md
+++ b/docs/06-cleanup.md
@@ -1,19 +1,10 @@
 # Deleting the Cluster and Cleaning up
-Cleaning up your cluster is trivial. However, on the off chance that the
-cleanup fails, you will be left with AWS resources that are undeleted.
-Finding them can be tricky, but they have a key:value tag of
-`openshiftClusterID:<cluster_uuid>` and then you can carefully delete them by
-hand.
 
-Just in case, be sure to grab the UUID before destroying the cluster:
-
-    oc get clusterversion -o jsonpath='{.spec.clusterID}{"\n"}' version
-
-If you are trying to destroy your cluster because of a failed installation,
-you may not be able to use `oc`. In that case, you can look for the UUID in
-the `metadata.json` asset:
-
-    jq -r .clusterID metadata.json
+Cleaning up your cluster is straightforward *if* you preserved the
+`metadata.json` file from cluster creation.  It is usually possible to
+reconstruct the file if you lose it, but that depends on still having
+a functioning cluster or poking around in AWS, so it's better to just
+hang on to the file.
 
 The following command will read `metadata.json` and remove the
 OpenShift 4 cluster and all underlying AWS resources that were created


### PR DESCRIPTION
The installer no longer sets this since openshift/installer@56f47611 (openshift/installer#1280).  Preserving the file seems fairly straightforward, so I'm just dropping the reconstruction nodes.  We may be able to add something similar back once the format stabilizes again.