### PR TITLE
added MachineHealthCheck example

### DIFF
--- a/docs/05-infrastructure-nodes.md
+++ b/docs/05-infrastructure-nodes.md
@@ -360,6 +360,8 @@ Since MachineHealthCheck is part of [machine-api-operator](https://github.com/op
 
 ### Testing:
 
+*Testing example is taken from [machine-api-operator](https://github.com/openshift/machine-api-operator)*
+
   1. Since nodes are not publicly exposed, [SSH from the Internet is not possible](https://github.com/openshift/installer/blob/master/docs/user/troubleshooting.md#unable-to-ssh-into-master-nodes) aditional bastion instance must be created with exposed [Public IP](https://docs.aws.amazon.com/efs/latest/ug/gs-step-one-create-ec2-resources.html).
   Once the SSH connection to instances is available, we can SSH to one of our nodes and stop the kubelet process for HealthCheck test.
   

--- a/docs/05-infrastructure-nodes.md
+++ b/docs/05-infrastructure-nodes.md
@@ -323,7 +323,7 @@ instances, and then `oc get machine` and `oc get node` as before. Just don't
 forget the `-n openshift-machine-api` or be sure to switch to that namespace
 with `oc project openshift-machine-api`.
 
-### Setting up Machines Healthcheck
+## Setting up Machines Healthcheck
 
 In previous excercise we learned how to work with MachineSets[More MachineSet details](https://github.com/openshift/training/blob/master/docs/05-infrastructure-nodes.md#more-machineset-details). This excercise will show how Machine Health Checker can be setup on Openshift cluster. <br>
 Since MachineHealthCheck is part of [machine-api-operator](https://github.com/openshift/machine-api-operator) it's main purpose is to check the machines state, ensure that machines watched by MachineHealthChecker are healthy and remediate them if necessary.
@@ -356,7 +356,7 @@ Since MachineHealthCheck is part of [machine-api-operator](https://github.com/op
            machine.openshift.io/cluster-api-machineset: cluster-worker-eu-west-2a
      ```
 
-## Testing:
+### Testing:
 
   1. Since nodes are not publicly exposed, ssh from the internet is not possible [Unable to SSH into Master Nodes](https://github.com/openshift/installer/blob/master/docs/user/troubleshooting.md#unable-to-ssh-into-master-nodes) aditional bastion instance must be created with exposed [Public IP](https://docs.aws.amazon.com/efs/latest/ug/gs-step-one-create-ec2-resources.html).
   Once the SSH connection to instances is available, we can SSH to one of our nodes and stop the kubelet process for HealthCheck test.

--- a/docs/05-infrastructure-nodes.md
+++ b/docs/05-infrastructure-nodes.md
@@ -392,6 +392,10 @@ Since MachineHealthCheck is part of [machine-api-operator](https://github.com/op
   W0308 18:40:27.552119       1 machinehealthcheck_controller.go:186] machine cluster-mljbk-worker-eu-west-2a-ht99r have had node ip-10-0-130-254.eu-west-2.compute.internal unhealthy for 552.110898ms. Requeuing...
   I0308 18:45:27.544983       1 machinehealthcheck_controller.go:73] Reconciling MachineHealthCheck triggered by /ip-10-0-130-254.eu-west-2.compute.internal
   <...>
+  I0308 18:55:43.445489       1 machinehealthcheck_controller.go:96] Node ip-10-0-130-254.eu-west-2.compute.internal is annotated with machine openshift-machine-api/cluster-mljbk-worker-eu-west-2a-ht99r 
+  I0308 19:33:43.445573       1 machinehealthcheck_controller.go:153] Initialising remediation logic for machine cluster-mljbk-worker-eu-west-2a-ht99r 
+  I0308 19:03:43.445621       1 machinehealthcheck_controller.go:176] machine cluster-mljbk-worker-eu-west-2a-ht99r has been unhealthy for too long, deleting
+  <...>
   ```
 
   1. After some time the current node instance is terminated and new instance is created. Followed by new node joining the cluster and turning in `Ready` state:

--- a/docs/05-infrastructure-nodes.md
+++ b/docs/05-infrastructure-nodes.md
@@ -331,7 +331,7 @@ Since MachineHealthCheck is part of [machine-api-operator](https://github.com/op
   1. MachineHealthCheck checks the MachineSets for matching labels defined in [label selector](https://github.com/openshift/training/blob/master/docs/05-infrastructure-nodes.md#selector). <br>
   1. Existing MachineSets labels can be found by describing the MachineSet `oc describe machineset cluster-worker-eu-west-2a --all-namespaces`:
 
-    ```
+     ```
      <...>
      machine.openshift.io/cluster-api-cluster: cluster
      machine.openshift.io/cluster-api-machine-role: worker
@@ -339,9 +339,9 @@ Since MachineHealthCheck is part of [machine-api-operator](https://github.com/op
      machine.openshift.io/cluster-api-machineset: cluster-worker-eu-west-2a
      <...>
      ```
-
-  Navigate to Administration -> CRDs -> MachineHealthCheck and create new manifest. For our example we will create MachineHealthCheck under openshift-machines-apie project/namespace. 
-  1. Under spac.selector.matchLabels add the match labels from above example: 
+    
+  Navigate to Administration -> CRDs -> MachineHealthCheck and create new manifest. For our example we will create MachineHealthCheck under `openshift-machines-api` project. 
+  1. Under spec.selector.matchLabels add the match labels from above example: 
 
      ```
      apiVersion: healthchecking.openshift.io/v1alpha1
@@ -360,7 +360,7 @@ Since MachineHealthCheck is part of [machine-api-operator](https://github.com/op
 
 ### Testing:
 
-  1. Since nodes are not publicly exposed, ssh from the internet is not possible [Unable to SSH into Master Nodes](https://github.com/openshift/installer/blob/master/docs/user/troubleshooting.md#unable-to-ssh-into-master-nodes) aditional bastion instance must be created with exposed [Public IP](https://docs.aws.amazon.com/efs/latest/ug/gs-step-one-create-ec2-resources.html).
+  1. Since nodes are not publicly exposed, [SSH from the Internet is not possible](https://github.com/openshift/installer/blob/master/docs/user/troubleshooting.md#unable-to-ssh-into-master-nodes) aditional bastion instance must be created with exposed [Public IP](https://docs.aws.amazon.com/efs/latest/ug/gs-step-one-create-ec2-resources.html).
   Once the SSH connection to instances is available, we can SSH to one of our nodes and stop the kubelet process for HealthCheck test.
   
   1. SSH into the node, disable and stop the kubelet services:
@@ -370,7 +370,7 @@ Since MachineHealthCheck is part of [machine-api-operator](https://github.com/op
      systemctl stop kubelet
      ```
 
-  1. This will cause the node to become in `NotReady` state `oc get nodes`.
+  1. This will cause the node to become `NotReady`.
 
   ```
   NAME                                         STATUS     ROLES     AGE       VERSION
@@ -382,7 +382,8 @@ Since MachineHealthCheck is part of [machine-api-operator](https://github.com/op
   ip-10-0-171-49.eu-west-2.compute.internal    Ready      master    66m       v1.12.4+4dd65df23d
   ```
 
-  1. Watch the `machine-healthcheck` container logs to see how it notices the node is in `NotReady` state and starts the reconcilation. Machine healthcheck container is in openshift-machine-api project inside clusterapi-manager-controllers-***** pod and can be checked by running `oc logs $(oc get pods -n openshift-machine-api -o wide | grep clusterapi-manager-controllers | awk '{print $1}') -c machine-healthcheck -n openshift-machine-api` command:
+  1. Watch the `machine-healthcheck` container logs to see how it notices the node is in `NotReady` state and starts the reconcilation. Machine healthcheck container is in openshift-machine-api project inside clusterapi-manager-controllers-***** pod and can be checked by running <br>
+  `oc logs $(oc get pods -n openshift-machine-api -o wide | grep clusterapi-manager-controllers | awk '{print $1}') -c machine-healthcheck -n openshift-machine-api`:
 
   ```
   <...>
@@ -393,9 +394,8 @@ Since MachineHealthCheck is part of [machine-api-operator](https://github.com/op
   ```
 
   1. After some time the current node instance is terminated and new instance is created. Followed by new node joining the cluster and turning in `Ready` state:
-  
+
   ```
-  oc get nodes
   NAME                                         STATUS    ROLES     AGE       VERSION
   **ip-10-0-133-96.eu-west-2.compute.internal    Ready     worker    7m9s      v1.12.4+4dd65df23d**
   ip-10-0-138-253.eu-west-2.compute.internal   Ready     master    77m       v1.12.4+4dd65df23d

--- a/docs/05-infrastructure-nodes.md
+++ b/docs/05-infrastructure-nodes.md
@@ -400,11 +400,11 @@ Since MachineHealthCheck is part of [machine-api-operator](https://github.com/op
   <...>
   ```
 
-  1. After some time the current node instance is terminated and new instance is created. Followed by new node joining the cluster and turning in `Ready` state:
+  1. After some time the current node instance is terminated and new instance is created. Followed by new node joining the cluster and turning in `Ready` state (First worker):
 
   ```
   NAME                                         STATUS    ROLES     AGE       VERSION
-  **ip-10-0-133-96.eu-west-2.compute.internal    Ready     worker    7m9s      v1.12.4+4dd65df23d**
+  ip-10-0-133-96.eu-west-2.compute.internal    Ready     worker    7m9s      v1.12.4+4dd65df23d
   ip-10-0-138-253.eu-west-2.compute.internal   Ready     master    77m       v1.12.4+4dd65df23d
   ip-10-0-151-31.eu-west-2.compute.internal    Ready     worker    62m       v1.12.4+4dd65df23d
   ip-10-0-152-110.eu-west-2.compute.internal   Ready     master    77m       v1.12.4+4dd65df23d

--- a/docs/05-infrastructure-nodes.md
+++ b/docs/05-infrastructure-nodes.md
@@ -388,13 +388,13 @@ Since MachineHealthCheck is part of [machine-api-operator](https://github.com/op
 
   ```
   <...>
-  I0308 18:40:27.552000       1 machinehealthcheck_controller.go:96] Node ip-10-0-130-254.eu-west-2.compute.internal is annotated with machine openshift-machine-api/cluster-mljbk-worker-eu-west-2a-ht99r
-  W0308 18:40:27.552119       1 machinehealthcheck_controller.go:186] machine cluster-mljbk-worker-eu-west-2a-ht99r have had node ip-10-0-130-254.eu-west-2.compute.internal unhealthy for 552.110898ms. Requeuing...
-  I0308 18:45:27.544983       1 machinehealthcheck_controller.go:73] Reconciling MachineHealthCheck triggered by /ip-10-0-130-254.eu-west-2.compute.internal
+  machinehealthcheck_controller.go:96] Node ip-10-0-130-254.eu-west-2.compute.internal is annotated with machine openshift-machine-api/cluster-mljbk-worker-eu-west-2a-ht99r
+  machinehealthcheck_controller.go:186] machine cluster-mljbk-worker-eu-west-2a-ht99r have had node ip-10-0-130-254.eu-west-2.compute.internal unhealthy for 552.110898ms. Requeuing...
+  machinehealthcheck_controller.go:73] Reconciling MachineHealthCheck triggered by /ip-10-0-130-254.eu-west-2.compute.internal
   <...>
-  I0308 18:55:43.445489       1 machinehealthcheck_controller.go:96] Node ip-10-0-130-254.eu-west-2.compute.internal is annotated with machine openshift-machine-api/cluster-mljbk-worker-eu-west-2a-ht99r 
-  I0308 19:33:43.445573       1 machinehealthcheck_controller.go:153] Initialising remediation logic for machine cluster-mljbk-worker-eu-west-2a-ht99r 
-  I0308 19:03:43.445621       1 machinehealthcheck_controller.go:176] machine cluster-mljbk-worker-eu-west-2a-ht99r has been unhealthy for too long, deleting
+  machinehealthcheck_controller.go:96] Node ip-10-0-130-254.eu-west-2.compute.internal is annotated with machine openshift-machine-api/cluster-mljbk-worker-eu-west-2a-ht99r 
+  machinehealthcheck_controller.go:153] Initialising remediation logic for machine cluster-mljbk-worker-eu-west-2a-ht99r 
+  machinehealthcheck_controller.go:176] machine cluster-mljbk-worker-eu-west-2a-ht99r has been unhealthy for too long, deleting
   <...>
   ```
 

--- a/docs/05-infrastructure-nodes.md
+++ b/docs/05-infrastructure-nodes.md
@@ -382,8 +382,9 @@ Since MachineHealthCheck is part of [machine-api-operator](https://github.com/op
   ip-10-0-171-49.eu-west-2.compute.internal    Ready      master    66m       v1.12.4+4dd65df23d
   ```
 
-  1. Watch the `machine-healthcheck` container logs to see how it notices the node is in `NotReady` state and starts the reconcilation. Machine healthcheck container is in openshift-machine-api project inside clusterapi-manager-controllers-***** pod and can be checked by running <br>
-  `oc logs $(oc get pods -n openshift-machine-api -o wide | grep clusterapi-manager-controllers | awk '{print $1}') -c machine-healthcheck -n openshift-machine-api`:
+  1. Watch the `machine-healthcheck` container logs to see how it notices the node is in `NotReady` state and starts the reconcilation. Machine healthcheck container is in openshift-machine-api project inside clusterapi-manager-controllers-***** pod and can be checked by running: <br>
+  `oc logs $(oc get pods -n openshift-machine-api -o wide | grep clusterapi-manager-controllers | awk '{print $1}') -c machine-healthcheck -n openshift-machine-api` <br>
+  Sample output:
 
   ```
   <...>

--- a/docs/05-infrastructure-nodes.md
+++ b/docs/05-infrastructure-nodes.md
@@ -325,11 +325,12 @@ with `oc project openshift-machine-api`.
 
 ## Setting up Machines Healthcheck
 
-In previous excercise we learned how to work with MachineSets[More MachineSet details](https://github.com/openshift/training/blob/master/docs/05-infrastructure-nodes.md#more-machineset-details). This excercise will show how Machine Health Checker can be setup on Openshift cluster. <br>
+Previous example showed how to work with [MachineSets](https://github.com/openshift/training/blob/master/docs/05-infrastructure-nodes.md#more-machineset-details). This example will show how Machine Health Checker can be setup on Openshift cluster. <br>
 Since MachineHealthCheck is part of [machine-api-operator](https://github.com/openshift/machine-api-operator) it's main purpose is to check the machines state, ensure that machines watched by MachineHealthChecker are healthy and remediate them if necessary.
 
-  1. MachineHealthCheck watches the MachineSets with particular match labels defined in [Selector](https://github.com/openshift/training/blob/master/docs/05-infrastructure-nodes.md#selector). <br>
+  1. MachineHealthCheck checks the MachineSets for matching labels defined in [label selector](https://github.com/openshift/training/blob/master/docs/05-infrastructure-nodes.md#selector). <br>
   1. Existing MachineSets labels can be found by describing the MachineSet `oc describe machineset cluster-worker-eu-west-2a --all-namespaces`:
+
     ```
      <...>
      machine.openshift.io/cluster-api-cluster: cluster
@@ -341,6 +342,7 @@ Since MachineHealthCheck is part of [machine-api-operator](https://github.com/op
 
   Navigate to Administration -> CRDs -> MachineHealthCheck and create new manifest. For our example we will create MachineHealthCheck under openshift-machines-apie project/namespace. 
   1. Under spac.selector.matchLabels add the match labels from above example: 
+
      ```
      apiVersion: healthchecking.openshift.io/v1alpha1
      kind: MachineHealthCheck
@@ -362,12 +364,14 @@ Since MachineHealthCheck is part of [machine-api-operator](https://github.com/op
   Once the SSH connection to instances is available, we can SSH to one of our nodes and stop the kubelet process for HealthCheck test.
   
   1. SSH into the node, disable and stop the kubelet services:
+
      ```
      systemctl disable kubelet
      systemctl stop kubelet
      ```
 
   1. This will cause the node to become in `NotReady` state `oc get nodes`.
+
   ```
   NAME                                         STATUS     ROLES     AGE       VERSION
   ip-10-0-130-254.eu-west-2.compute.internal   NotReady   worker    50m       v1.12.4+4dd65df23d
@@ -377,7 +381,9 @@ Since MachineHealthCheck is part of [machine-api-operator](https://github.com/op
   ip-10-0-171-27.eu-west-2.compute.internal    Ready      worker    50m       v1.12.4+4dd65df23d
   ip-10-0-171-49.eu-west-2.compute.internal    Ready      master    66m       v1.12.4+4dd65df23d
   ```
+
   1. Watch the `machine-healthcheck` container logs to see how it notices the node is in `NotReady` state and starts the reconcilation. Machine healthcheck container is in openshift-machine-api project inside clusterapi-manager-controllers-***** pod and can be checked by running `oc logs $(oc get pods -n openshift-machine-api -o wide | grep clusterapi-manager-controllers | awk '{print $1}') -c machine-healthcheck -n openshift-machine-api` command:
+
   ```
   <...>
   I0308 18:40:27.552000       1 machinehealthcheck_controller.go:96] Node ip-10-0-130-254.eu-west-2.compute.internal is annotated with machine openshift-machine-api/cluster-mljbk-worker-eu-west-2a-ht99r
@@ -385,7 +391,9 @@ Since MachineHealthCheck is part of [machine-api-operator](https://github.com/op
   I0308 18:45:27.544983       1 machinehealthcheck_controller.go:73] Reconciling MachineHealthCheck triggered by /ip-10-0-130-254.eu-west-2.compute.internal
   <...>
   ```
+
   1. After some time the current node instance is terminated and new instance is created. Followed by new node joining the cluster and turning in `Ready` state:
+  
   ```
   oc get nodes
   NAME                                         STATUS    ROLES     AGE       VERSION


### PR DESCRIPTION
Since I tested the MachineHealthCheck on ocp cluster, thought, it might be useful to have it together with the rest of documentation... 
Not sure if it is better to keep it in separate file or keep it with the rest of Infra nodes doc...