### PR TITLE
Update autoscaler example API versions in assests

### DIFF
--- a/assets/cluster-autoscaler.yaml
+++ b/assets/cluster-autoscaler.yaml
@@ -1,4 +1,4 @@
-apiVersion: "autoscaling.openshift.io/v1alpha1"
+apiVersion: "autoscaling.openshift.io/v1"
 kind: "ClusterAutoscaler"
 metadata:
   name: "default"

--- a/assets/machine-autoscale-example.yaml
+++ b/assets/machine-autoscale-example.yaml
@@ -2,7 +2,7 @@ kind: List
 metadata: {}
 apiVersion: v1
 items:
-- apiVersion: "autoscaling.openshift.io/v1alpha1"
+- apiVersion: "autoscaling.openshift.io/v1beta1"
   kind: "MachineAutoscaler"
   metadata:
     generateName: autoscale-<aws-region-az>-
@@ -14,7 +14,7 @@ items:
       apiVersion: machine.openshift.io/v1beta1
       kind: MachineSet
       name: <clusterid>-worker-<aws-region-az>
-- apiVersion: "autoscaling.openshift.io/v1alpha1"
+- apiVersion: "autoscaling.openshift.io/v1beta1"
   kind: "MachineAutoscaler"
   metadata:
     generateName: autoscale-<aws-region-az>-
@@ -26,7 +26,7 @@ items:
       apiVersion: machine.openshift.io/v1beta1
       kind: MachineSet
       name: <clusterid>-worker-<aws-region-az>
-- apiVersion: "autoscaling.openshift.io/v1alpha1"
+- apiVersion: "autoscaling.openshift.io/v1beta1"
   kind: "MachineAutoscaler"
   metadata:
     generateName: autoscale-<aws-region-az>-


### PR DESCRIPTION
Updating API versions in the autoscaler examples in /assets to match working versions.